### PR TITLE
Fix Breadcrumb Navigation and Handle Navigation Errors in SubSection

### DIFF
--- a/AtlasToolbox/MainWindow.xaml.cs
+++ b/AtlasToolbox/MainWindow.xaml.cs
@@ -42,7 +42,7 @@ namespace AtlasToolbox
             if (RegistryHelper.IsMatch("HKLM\\SOFTWARE\\AtlasOS\\Toolbox", "OnStartup", 1)) this.Closed += AppBehaviorHelper.HideApp;
             else this.Closed += AppBehaviorHelper.CloseApp;
         }
-        
+
         /// <summary>
         /// Gets the window Xaml root for ContentDialogs
         /// </summary>
@@ -51,7 +51,7 @@ namespace AtlasToolbox
         {
             return this.Content.XamlRoot;
         }
-        
+
         /// <summary>
         /// navigates to the correct page when a navigation item is clicked
         /// </summary>
@@ -72,7 +72,7 @@ namespace AtlasToolbox
                 ContentFrame.Navigate(typeof(Views.SettingsPage), null, new DrillInNavigationTransitionInfo());
                 return;
             }
-            
+
             switch (args.InvokedItemContainer.Tag.ToString())
             {
                 case "AtlasToolbox.Views.SoftwarePage":
@@ -117,17 +117,32 @@ namespace AtlasToolbox
         {
             NavigationViewControl.IsBackEnabled = ContentFrame.CanGoBack;
             NavigationViewControl.Header = null;
-            if (App.CurrentCategory != null && App.CurrentCategory != "SettingsItem")
+
+            if (ContentFrame.SourcePageType != typeof(Views.SubSection))
             {
-                NavigationViewControl.SelectedItem = NavigationViewControl.MenuItems
-                    .OfType<NavigationViewItem>()
-                    .First(n => n.Tag.Equals(App.CurrentCategory));
+                if (App.CurrentCategory != null && App.CurrentCategory != "SettingsItem")
+                {
+                    try
+                    {
+                        NavigationViewControl.SelectedItem = NavigationViewControl.MenuItems
+                            .OfType<NavigationViewItem>()
+                            .First(n => n.Tag.Equals(App.CurrentCategory));
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        App.logger.Error($"No matching NavigationViewItem found for category: {App.CurrentCategory}");
+                    }
+                }
+                else
+                {
+                    NavigationViewControl.SelectedItem = (NavigationViewItem)NavigationViewControl.SettingsItem;
+                }
             }
-            else
+
+            if (ContentFrame.SourcePageType == typeof(Views.SettingsPage))
             {
                 NavigationViewControl.SelectedItem = (NavigationViewItem)NavigationViewControl.SettingsItem;
             }
-            if (ContentFrame.SourcePageType == typeof(Views.SettingsPage)) NavigationViewControl.SelectedItem = (NavigationViewItem)NavigationViewControl.SettingsItem;
         }
 
         /// <summary>

--- a/AtlasToolbox/Views/SubSection.xaml.cs
+++ b/AtlasToolbox/Views/SubSection.xaml.cs
@@ -44,7 +44,8 @@ namespace AtlasToolbox.Views
                 Links.ItemsSource = item.LinksViewModels;
                 SubMenuItems.ItemsSource = item.ConfigurationSubMenuViewModels;
                 ConfigurationButton.ItemsSource = item.ConfigurationButtonViewModels;
-                Folder folder = new Folder { 
+                Folder folder = new Folder
+                {
                     Name = item.Name,
                 };
                 item2.Add(folder);
@@ -72,10 +73,15 @@ namespace AtlasToolbox.Views
         {
             var settingCard = sender as SettingsCard;
             var item = settingCard.DataContext as ConfigurationSubMenuViewModel;
-
             var template = SubMenuItems.ItemTemplate;
 
-            Frame.Navigate(typeof(SubSection), new Tuple<ConfigurationSubMenuViewModel, DataTemplate>(item, template), new SlideNavigationTransitionInfo() { Effect = SlideNavigationTransitionEffect.FromRight });
+            var breadcrumbItems = BreadcrumbBar.ItemsSource as ObservableCollection<Folder>;
+            if (breadcrumbItems == null)
+            {
+                breadcrumbItems = new ObservableCollection<Folder>();
+            }
+
+            Frame.Navigate(typeof(SubSection), new Tuple<ConfigurationSubMenuViewModel, DataTemplate, object>(item, template, breadcrumbItems), new SlideNavigationTransitionInfo() { Effect = SlideNavigationTransitionEffect.FromRight });
         }
 
         private void ToggleSwitch_Loaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Modified OnCardClicked to pass the BreadcrumbBar.ItemsSource as the third parameter during navigation. This ensures the SubSection's OnNavigatedTo method receives the expected breadcrumb data.