### PR TITLE
Beta v0.1.6

### DIFF
--- a/AtlasToolbox/app.config
+++ b/AtlasToolbox/app.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
 	<appSettings>
-		<add key="AtlasVersion" value="0.5.0"/>
+		<add key="AtlasVersion" value="0.4.1"/>
 		<add key="ToolboxVersion" value="v0.1.6 Beta"/>
 	</appSettings>
 </configuration>

--- a/AtlasToolbox/app.config
+++ b/AtlasToolbox/app.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
 	<appSettings>
-		<add key="AtlasVersion" value="0.4.1"/>
-		<add key="ToolboxVersion" value="v0.1.2 Beta"/>
+		<add key="AtlasVersion" value="0.5.0"/>
+		<add key="ToolboxVersion" value="v0.1.6 Beta"/>
 	</appSettings>
 </configuration>

--- a/Installer/setup.iss
+++ b/Installer/setup.iss
@@ -66,4 +66,4 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: de
 
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
-
+Filename: {sys}\taskkill.exe; Parameters: "/f /im AtlasToolbox.exe"; Flags: skipifdoesntexist runhidden

--- a/Installer/setup.iss
+++ b/Installer/setup.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Atlas Toolbox"
-#define MyAppVersion "0.1.5"
+#define MyAppVersion "0.1.6"
 #define MyAppPublisher "AtlasOS"
 #define MyAppURL "https://www.atlasos.net/"
 #define MyAppExeName "AtlasToolbox.exe"


### PR DESCRIPTION
# 🧰Atlas Toolbox Beta Release v0.1.6
We are happy to announce the release the sixth Beta for the Atlas Toolbox. This updates bring minor bug fixes and new features
## :pencil: Changelog
### Features
-  Swedish language support
-  OTA Updates
### Bug fixes
- Fixed region settings button not working
## Note about OTA Updates
Since this is the first version with OTA Updates, you will need to reinstall the Toolbox with the installer, however for future releases you will be able to directly upgrade in the app.