### PR TITLE
Fix IncompatibleVersionWindow NullReferenceException by moving LoadText() call

### DIFF
--- a/AtlasToolbox/Views/IncompatibleVersionWindow.xaml.cs
+++ b/AtlasToolbox/Views/IncompatibleVersionWindow.xaml.cs
@@ -35,8 +35,8 @@ namespace AtlasToolbox
             WindowManager.Get(this).Height = 850;
             CenterWindowOnScreen();
             ExtendsContentIntoTitleBar = true;
-            LoadText();
             this.InitializeComponent();
+            LoadText();
         }
 
         private void LoadText()


### PR DESCRIPTION
When launching the app on unsupported version, the `IncompatibleVersionWindow` constructor calls `LoadText()` _before_ the XAML components are initialized. This causes a `NullReferenceException` as the `IncompatibleVer` control isn’t yet created.

**Error from logs:**  
```log
2025-06-21 20:32:13.2403 Info: App Started 
2025-06-21 20:32:13.3997 Info: Building host 
2025-06-21 20:32:13.4187 Info: Starting host 
2025-06-21 20:32:13.4187 Info: Finished initializing components 
2025-06-21 20:32:13.6321 Error: Unhandled exception occurred System.NullReferenceException: Object reference not set to an instance of an object.
   at AtlasToolbox.IncompatibleVersionWindow.LoadText() in D:\a\atlas-toolbox\atlas-toolbox\AtlasToolbox\Views\IncompatibleVersionWindow.xaml.cs:line 44
   at AtlasToolbox.IncompatibleVersionWindow..ctor() in D:\a\atlas-toolbox\atlas-toolbox\AtlasToolbox\Views\IncompatibleVersionWindow.xaml.cs:line 38
   at AtlasToolbox.App.OnLaunched(LaunchActivatedEventArgs args) in D:\a\atlas-toolbox\atlas-toolbox\AtlasToolbox\App.xaml.cs:line 153
   at Microsoft.UI.Xaml.Application.Microsoft.UI.Xaml.IApplicationOverrides.OnLaunched(LaunchActivatedEventArgs args)
   at ABI.Microsoft.UI.Xaml.IApplicationOverrides.Do_Abi_OnLaunched_0(IntPtr thisPtr, IntPtr args)
````

Moving the `LoadText()` call to _after_ `this.InitializeComponent()` ensures the XAML elements are fully wired up before we attempt to set their text.  
```diff
- LoadText();
  this.InitializeComponent();
+ LoadText();
````

I have verified this change locally by building the solution and confirming the “Incompatible Version” window displays its text correctly without errors.

---

## Screenshots

**Before (VS error):**
![Error screenshot](https://github.com/user-attachments/assets/9f6f4409-28be-4fb5-9e9f-24b45d96c6a9)

**After (working window):**
![Working window screenshot](https://github.com/user-attachments/assets/545e5e67-462c-4cd5-be58-764e65e8db62)
