### PR TITLE
Beta v0.1.8

### DIFF
--- a/AtlasToolbox/Commands/ConfigurationButtonsCommand/CurrentVBSConfigurationCommand.cs
+++ b/AtlasToolbox/Commands/ConfigurationButtonsCommand/CurrentVBSConfigurationCommand.cs
@@ -12,7 +12,7 @@ namespace AtlasToolbox.Commands.ConfigurationButtonsCommand
     {
         protected override async Task ExecuteAsync(object parameter)
         {
-            await Task.Run(() => { CommandPromptHelper.RunCommand(@$"{Environment.GetEnvironmentVariable("windir")}\AtlasModules\Toolbox\Scripts\vbsCurrentConfig.cmd", false); });
+            await Task.Run(() => { ProcessHelper.StartShellExecute($@"{Environment.GetEnvironmentVariable("windir")}\AtlasModules\Toolbox\Scripts\vbsCurrentConfig.cmd"); });
         }
     }
 }

--- a/AtlasToolbox/Commands/ConfigurationButtonsCommand/FixErrorsCommand.cs
+++ b/AtlasToolbox/Commands/ConfigurationButtonsCommand/FixErrorsCommand.cs
@@ -12,7 +12,8 @@ namespace AtlasToolbox.Commands.ConfigurationButtonsCommand
     {
         protected override async Task ExecuteAsync(object parameter)
         {
-            await Task.Run(() => { CommandPromptHelper.RunCommand(@$"{Environment.GetEnvironmentVariable("windir")}AtlasModules\Toolbox\Scripts\Troubleshooting\Fix Errors 2502 and 2503.cmd", false); });
+            //await Task.Run(() => { CommandPromptHelper.RunProcess(@$"{Environment.GetEnvironmentVariable("windir")}\AtlasModules\Toolbox\Scripts\Troubleshooting\Fix Errors 2502 and 2503.cmd", "", false); });
+            await Task.Run(() => { ProcessHelper.StartShellExecute(@$"{Environment.GetEnvironmentVariable("windir")}\AtlasModules\Toolbox\Scripts\Troubleshooting\Fix Errors 2502 and 2503.cmd"); });
         }
     }
 }

--- a/AtlasToolbox/Commands/ConfigurationButtonsCommand/FixErrorsCommand.cs
+++ b/AtlasToolbox/Commands/ConfigurationButtonsCommand/FixErrorsCommand.cs
@@ -12,7 +12,6 @@ namespace AtlasToolbox.Commands.ConfigurationButtonsCommand
     {
         protected override async Task ExecuteAsync(object parameter)
         {
-            //await Task.Run(() => { CommandPromptHelper.RunProcess(@$"{Environment.GetEnvironmentVariable("windir")}\AtlasModules\Toolbox\Scripts\Troubleshooting\Fix Errors 2502 and 2503.cmd", "", false); });
             await Task.Run(() => { ProcessHelper.StartShellExecute(@$"{Environment.GetEnvironmentVariable("windir")}\AtlasModules\Toolbox\Scripts\Troubleshooting\Fix Errors 2502 and 2503.cmd"); });
         }
     }

--- a/AtlasToolbox/Commands/ConfigurationButtonsCommand/InstallOpenShellCommand.cs
+++ b/AtlasToolbox/Commands/ConfigurationButtonsCommand/InstallOpenShellCommand.cs
@@ -12,7 +12,7 @@ namespace AtlasToolbox.Commands.ConfigurationButtonsCommand
     {
         protected override async Task ExecuteAsync(object parameter)
         {
-            await Task.Run(() => { CommandPromptHelper.RunCommand(@$"{Environment.GetEnvironmentVariable("windir")}AtlasDesktop\4. Interface Tweaks\Start Menu\Install Open-Shell.cmd", false); });
+            await Task.Run(() => { ProcessHelper.StartShellExecute(@$"{Environment.GetEnvironmentVariable("windir")}\AtlasDesktop\4. Interface Tweaks\Start Menu\Install Open-Shell.cmd"); });
         }
     }
 }

--- a/AtlasToolbox/Commands/ConfigurationButtonsCommand/InstallProcessExplorer.cs
+++ b/AtlasToolbox/Commands/ConfigurationButtonsCommand/InstallProcessExplorer.cs
@@ -12,7 +12,7 @@ namespace AtlasToolbox.Commands.ConfigurationButtonsCommand
     {
         protected override async Task ExecuteAsync(object parameter)
         {
-            await Task.Run(() => { CommandPromptHelper.RunCommand(@$"{Environment.GetEnvironmentVariable("windir")}AtlasDesktop\6. Advanced Configuration\Process Explorer\Install Process Explorer.cmd", false); });
+            await Task.Run(() => { ProcessHelper.StartShellExecute(@$"{Environment.GetEnvironmentVariable("windir")}\AtlasDesktop\6. Advanced Configuration\Process Explorer\Install Process Explorer.cmd"); });
         }
     }
 }

--- a/AtlasToolbox/Commands/ConfigurationButtonsCommand/NetworkAtlasDefaults.cs
+++ b/AtlasToolbox/Commands/ConfigurationButtonsCommand/NetworkAtlasDefaults.cs
@@ -12,7 +12,7 @@ namespace AtlasToolbox.Commands.ConfigurationButtonsCommand
     {
         protected override async Task ExecuteAsync(object parameter)
         {
-            await Task.Run(() => { CommandPromptHelper.RunCommand(@$"{Environment.GetEnvironmentVariable("windir")}AtlasModules\Toolbox\Scripts\Troubleshooting\TroubleshootingNetwork\AtlasDefault.cmd", false); });
+            await Task.Run(() => { ProcessHelper.StartShellExecute($@"{Environment.GetEnvironmentVariable("windir")}\AtlasModules\Toolbox\Scripts\Troubleshooting\TroubleshootingNetwork\AtlasDefault.cmd"); });
         }
     }
 }

--- a/AtlasToolbox/Commands/ConfigurationButtonsCommand/NetworkWindowsDefaults.cs
+++ b/AtlasToolbox/Commands/ConfigurationButtonsCommand/NetworkWindowsDefaults.cs
@@ -12,7 +12,7 @@ namespace AtlasToolbox.Commands.ConfigurationButtonsCommand
     {
         protected override async Task ExecuteAsync(object parameter)
         {
-            await Task.Run(() => { CommandPromptHelper.RunCommand(@$"{Environment.GetEnvironmentVariable("windir")}AtlasModules\Toolbox\Scripts\Troubleshooting\TroubleshootingNetwork\WindowsDefault.cmd", false); });
+            await Task.Run(() => { ProcessHelper.StartShellExecute($@"{Environment.GetEnvironmentVariable("windir")}\AtlasModules\Toolbox\Scripts\Troubleshooting\TroubleshootingNetwork\WindowsDefault.cmd"); });
         }
     }
 }

--- a/AtlasToolbox/Commands/ConfigurationButtonsCommand/RepairWindowsComponentsCommand.cs
+++ b/AtlasToolbox/Commands/ConfigurationButtonsCommand/RepairWindowsComponentsCommand.cs
@@ -12,7 +12,7 @@ namespace AtlasToolbox.Commands.ConfigurationButtonsCommand
     {
         protected override async Task ExecuteAsync(object parameter)
         {
-            await Task.Run(() => { CommandPromptHelper.RunCommand(@$"{Environment.GetEnvironmentVariable("windir")}AtlasModules\Toolbox\Scripts\Troubleshooting\Repair Windows Components.cmd", false); });
+            await Task.Run(() => { ProcessHelper.StartShellExecute($@"{Environment.GetEnvironmentVariable("windir")}\AtlasModules\Toolbox\Scripts\Troubleshooting\Repair Windows Components.cmd"); });
         }
     }
 }

--- a/AtlasToolbox/Commands/ConfigurationButtonsCommand/ResetFTHCommand.cs
+++ b/AtlasToolbox/Commands/ConfigurationButtonsCommand/ResetFTHCommand.cs
@@ -12,7 +12,7 @@ namespace AtlasToolbox.Commands.ConfigurationButtonsCommand
     {
         protected override async Task ExecuteAsync(object parameter)
         {
-            await Task.Run(() => { CommandPromptHelper.RunCommand(@$"{Environment.GetEnvironmentVariable("windir")}\System32\rundll32.exe", false); });
+            await Task.Run(() => { ProcessHelper.StartShellExecute($@"{Environment.GetEnvironmentVariable("windir")}\System32\rundll32.exe"); });
         }
     }
 }

--- a/AtlasToolbox/Commands/ConfigurationButtonsCommand/TelemetryComponentsCommand.cs
+++ b/AtlasToolbox/Commands/ConfigurationButtonsCommand/TelemetryComponentsCommand.cs
@@ -12,7 +12,7 @@ namespace AtlasToolbox.Commands.ConfigurationButtonsCommand
     {
         protected override async Task ExecuteAsync(object parameter)
         {
-            await Task.Run(() => { CommandPromptHelper.RunCommand(@$"{Environment.GetEnvironmentVariable("windir")}AtlasModules\Toolbox\Scripts\Troubleshooting\Telemetry Components.cmd", false); });
+            await Task.Run(() => { ProcessHelper.StartShellExecute($@"{Environment.GetEnvironmentVariable("windir")}\AtlasModules\Toolbox\Scripts\Troubleshooting\Telemetry Components.cmd"); });
         }
     }
 }

--- a/AtlasToolbox/Commands/ConfigurationButtonsCommand/ToggleDefenderCommand.cs
+++ b/AtlasToolbox/Commands/ConfigurationButtonsCommand/ToggleDefenderCommand.cs
@@ -13,7 +13,7 @@ namespace AtlasToolbox.Commands.ConfigurationButtonsCommand
         protected override async Task ExecuteAsync(object parameter)
         {
             await Task.Run(() => {
-                CommandPromptHelper.RunCommand(@$"{Environment.GetEnvironmentVariable("windir")}\AtlasModules\Toolbox\Scripts\toggleDefender.cmd", false);
+                ProcessHelper.StartShellExecute($@"{Environment.GetEnvironmentVariable("windir")}\AtlasModules\Toolbox\Scripts\toggleDefender.cmd");
             });
         }
     }

--- a/AtlasToolbox/Commands/ConfigurationButtonsCommand/UninstallProcessExplorer.cs
+++ b/AtlasToolbox/Commands/ConfigurationButtonsCommand/UninstallProcessExplorer.cs
@@ -12,7 +12,7 @@ namespace AtlasToolbox.Commands.ConfigurationButtonsCommand
     {
         protected override async Task ExecuteAsync(object parameter)
         {
-            await Task.Run(() => { CommandPromptHelper.RunCommand(@$"{Environment.GetEnvironmentVariable("windir")}AtlasDesktop\6. Advanced Configuration\Process Explorer\Uninstall Process Explorer.cmd", false); });
+            await Task.Run(() => { ProcessHelper.StartShellExecute($@"{Environment.GetEnvironmentVariable("windir")}\AtlasDesktop\6. Advanced Configuration\Process Explorer\Uninstall Process Explorer.cmd"); });
         }
     }
 }

--- a/AtlasToolbox/Commands/ConfigurationButtonsCommand/ViewCurrentValuesCommand.cs
+++ b/AtlasToolbox/Commands/ConfigurationButtonsCommand/ViewCurrentValuesCommand.cs
@@ -13,7 +13,7 @@ namespace AtlasToolbox.Commands.ConfigurationButtonsCommand
         protected override async Task ExecuteAsync(object parameter)
         {
             await Task.Run(() => {
-                CommandPromptHelper.RunCommand(@$"{Environment.GetEnvironmentVariable("windir")}\AtlasModules\Toolbox\Scripts\viewBootValues.cmd", false);
+                ProcessHelper.StartShellExecute(@$"{Environment.GetEnvironmentVariable("windir")}\AtlasModules\Toolbox\Scripts\viewBootValues.cmd");
             });
         }
     }

--- a/AtlasToolbox/MainWindow.xaml
+++ b/AtlasToolbox/MainWindow.xaml
@@ -64,27 +64,19 @@
             <NavigationView.Content>
                 <Grid>
                     <Frame x:Name="ContentFrame" Navigated="ContentFrame_Navigated" />
+                    <InfoBar
+                        x:Name="UpdateTitleBar"
+                        Margin="0,26,36,0"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Top"
+                        Background="#30313E"
+                        IsOpen="False">
+                        <InfoBar.ActionButton>
+                            <HyperlinkButton NavigateUri="https://github.com/atlas-os/atlas-toolbox/releases/latest" x:Name="LearnMoreBtn"/>
+                        </InfoBar.ActionButton>
+                    </InfoBar>
                 </Grid>
             </NavigationView.Content>
-
-            <!--<NavigationView.PaneFooter>
-                --><!--  Beta version message, to be removed at release  --><!--
-                <StackPanel>
-                    <InfoBar
-                        x:Name="UnstableCard"
-                        Margin="16,0,16,10"
-                        IsClosable="False"
-                        IsIconVisible="True"
-                        IsOpen="True"
-                        Severity="Warning" />
-                    <InfoBar
-                        x:Name="BetaVersionCard"
-                        Margin="16,0,16,0"
-                        IsClosable="False"
-                        IsIconVisible="True"
-                        IsOpen="True" />
-                </StackPanel>
-            </NavigationView.PaneFooter>-->
 
             <NavigationView.Resources>
                 <Thickness x:Key="NavigationViewContentMargin">0,48,0,0</Thickness>

--- a/AtlasToolbox/MainWindow.xaml
+++ b/AtlasToolbox/MainWindow.xaml
@@ -67,8 +67,8 @@
                 </Grid>
             </NavigationView.Content>
 
-            <NavigationView.PaneFooter>
-                <!--  Beta version message, to be removed at release  -->
+            <!--<NavigationView.PaneFooter>
+                --><!--  Beta version message, to be removed at release  --><!--
                 <StackPanel>
                     <InfoBar
                         x:Name="UnstableCard"
@@ -84,7 +84,7 @@
                         IsIconVisible="True"
                         IsOpen="True" />
                 </StackPanel>
-            </NavigationView.PaneFooter>
+            </NavigationView.PaneFooter>-->
 
             <NavigationView.Resources>
                 <Thickness x:Key="NavigationViewContentMargin">0,48,0,0</Thickness>

--- a/AtlasToolbox/MainWindow.xaml.cs
+++ b/AtlasToolbox/MainWindow.xaml.cs
@@ -32,10 +32,10 @@ namespace AtlasToolbox
 
             //Window parameters
             WindowManager.Get(this).Width = 1250;
-            WindowManager.Get(this).MinWidth = 1000;
+            WindowManager.Get(this).MinWidth = 720;
 
             WindowManager.Get(this).Height = 850;
-            WindowManager.Get(this).MinHeight = 800;
+            WindowManager.Get(this).MinHeight = 480;
 
             CenterWindowOnScreen();
             ExtendsContentIntoTitleBar = true;
@@ -72,18 +72,23 @@ namespace AtlasToolbox
                        new Microsoft.UI.Xaml.Media.Animation.EntranceNavigationTransitionInfo()
                        );
             SetTitleBar(AppTitleBar);
-
+            CheckUpdates();
             if (RegistryHelper.IsMatch("HKLM\\SOFTWARE\\AtlasOS\\Toolbox", "OnStartup", 1)) this.Closed += AppBehaviorHelper.HideApp;
             else this.Closed += AppBehaviorHelper.CloseApp;            
         }
 
+        private async void CheckUpdates()
+        {
+            bool update = await Task.Run(() => ToolboxUpdateHelper.CheckUpdates());
+            if (update)
+            {
+                UpdateTitleBar.IsOpen = true;
+            }
+        }
         public void LoadText()
         {
-            //UnstableCard.Title = App.GetValueFromItemList("Unstable");
-            //UnstableCard.Message = App.GetValueFromItemList("UnstableDescription");
-            //BetaVersionCard.Title = App.GetValueFromItemList("BetaVersion");
-            //BetaVersionCard.Message = App.GetValueFromItemList("BetaVersionDescription");
-
+            UpdateTitleBar.Title = App.GetValueFromItemList("NewUpdateMessage");
+            LearnMoreBtn.Content = App.GetValueFromItemList("LearnMore");
             Home.Content = App.GetValueFromItemList("Home_HeaderText");
             Software.Content = App.GetValueFromItemList("Software");
             GeneralConfig.Content = App.GetValueFromItemList("GeneralConfig");

--- a/AtlasToolbox/MainWindow.xaml.cs
+++ b/AtlasToolbox/MainWindow.xaml.cs
@@ -32,10 +32,10 @@ namespace AtlasToolbox
 
             //Window parameters
             WindowManager.Get(this).Width = 1250;
-            WindowManager.Get(this).MinWidth = 1250;
+            WindowManager.Get(this).MinWidth = 700;
 
             WindowManager.Get(this).Height = 850;
-            WindowManager.Get(this).MinHeight = 850;
+            WindowManager.Get(this).MinHeight = 500;
 
             CenterWindowOnScreen();
             ExtendsContentIntoTitleBar = true;
@@ -79,10 +79,10 @@ namespace AtlasToolbox
 
         public void LoadText()
         {
-            UnstableCard.Title = App.GetValueFromItemList("Unstable");
-            UnstableCard.Message = App.GetValueFromItemList("UnstableDescription");
-            BetaVersionCard.Title = App.GetValueFromItemList("BetaVersion");
-            BetaVersionCard.Message = App.GetValueFromItemList("BetaVersionDescription");
+            //UnstableCard.Title = App.GetValueFromItemList("Unstable");
+            //UnstableCard.Message = App.GetValueFromItemList("UnstableDescription");
+            //BetaVersionCard.Title = App.GetValueFromItemList("BetaVersion");
+            //BetaVersionCard.Message = App.GetValueFromItemList("BetaVersionDescription");
 
             Home.Content = App.GetValueFromItemList("Home_HeaderText");
             Software.Content = App.GetValueFromItemList("Software");

--- a/AtlasToolbox/MainWindow.xaml.cs
+++ b/AtlasToolbox/MainWindow.xaml.cs
@@ -32,10 +32,10 @@ namespace AtlasToolbox
 
             //Window parameters
             WindowManager.Get(this).Width = 1250;
-            WindowManager.Get(this).MinWidth = 700;
+            WindowManager.Get(this).MinWidth = 1000;
 
             WindowManager.Get(this).Height = 850;
-            WindowManager.Get(this).MinHeight = 500;
+            WindowManager.Get(this).MinHeight = 800;
 
             CenterWindowOnScreen();
             ExtendsContentIntoTitleBar = true;

--- a/AtlasToolbox/Services/ConfigurationServices/CopilotConfigurationService.cs
+++ b/AtlasToolbox/Services/ConfigurationServices/CopilotConfigurationService.cs
@@ -30,7 +30,7 @@ namespace AtlasToolbox.Services.ConfigurationServices
         {
             RegistryHelper.SetValue(ATLAS_STORE_KEY_NAME, STATE_VALUE_NAME, 0);
             RegistryHelper.SetValue(ATLAS_STORE_KEY_NAME, "path", @$"{Environment.GetEnvironmentVariable("windir")}\AtlasDesktop\3. General Configuration\AI Features\Microsoft Copilot\Disable Microsoft Copilot (default).cmd");
-            CommandPromptHelper.RunCommand(@$"{Environment.GetEnvironmentVariable("windir")}AtlasModules\Toolbox\Scripts\Copilot\DisableMicrosoftCopilot.cmd");
+            ProcessHelper.StartShellExecute(@$"{Environment.GetEnvironmentVariable("windir")}AtlasModules\Toolbox\Scripts\Copilot\DisableMicrosoftCopilot.cmd");
 
             _copilotConfigurationStore.CurrentSetting = IsEnabled();
         }
@@ -40,7 +40,7 @@ namespace AtlasToolbox.Services.ConfigurationServices
             RegistryHelper.SetValue(ATLAS_STORE_KEY_NAME, STATE_VALUE_NAME, 1);
             RegistryHelper.SetValue(ATLAS_STORE_KEY_NAME, "path", @$"{Environment.GetEnvironmentVariable("windir")}\AtlasDesktop\3. General Configuration\AI Features\Microsoft Copilot\Enable Microsoft Copilot.cmd");
 
-            CommandPromptHelper.RunCommand(@$"{Environment.GetEnvironmentVariable("windir")}AtlasModules\Toolbox\Scripts\Copilot\EnableMicrosoftCopilot.cmd");
+            ProcessHelper.StartShellExecute(@$"{Environment.GetEnvironmentVariable("windir")}AtlasModules\Toolbox\Scripts\Copilot\EnableMicrosoftCopilot.cmd");
 
             _copilotConfigurationStore.CurrentSetting = IsEnabled();
         }

--- a/AtlasToolbox/Utils/CompatibilityHelper.cs
+++ b/AtlasToolbox/Utils/CompatibilityHelper.cs
@@ -15,11 +15,13 @@ namespace AtlasToolbox.Utils
         /// <returns></returns>
         public static bool IsCompatible()
         {
-            string toolboxVersion = ConfigurationManager.AppSettings.Get("AtlasVersion");
+            string[] compatibleVersions = ConfigurationManager.AppSettings.Get("AtlasVersion").Split(',');
             string atlasVersion = (string)RegistryHelper.GetValue("HKLM\\SOFTWARE\\AME\\Playbooks\\Applied\\{00000000-0000-4000-6174-6C6173203A33}", "version");
-
-            if (toolboxVersion == atlasVersion) return true;
-            else return false;
+            foreach (string version in compatibleVersions)
+            {
+                if (atlasVersion == version) return true;
+            }
+            return false;
         }
     }
 }

--- a/AtlasToolbox/Views/HomePage.xaml
+++ b/AtlasToolbox/Views/HomePage.xaml
@@ -51,7 +51,7 @@
                             Margin="75,0,0,0"
                             VerticalAlignment="Center"
                             Orientation="Vertical">
-                            
+
                             <TextBlock
                                 x:Name="subHeaderBlock"
                                 FontSize="18"
@@ -78,7 +78,6 @@
                     Grid.Row="1"
                     Grid.Column="1"
                     Height="225"
-                    MinWidth="200"
                     Margin="0,10,36,10"
                     VerticalAlignment="Top"
                     Background="{ThemeResource ControlFillColorDefault}"

--- a/AtlasToolbox/Views/HomePage.xaml.cs
+++ b/AtlasToolbox/Views/HomePage.xaml.cs
@@ -69,7 +69,7 @@ namespace AtlasToolbox.Views
                 }
                 else
                 {
-                    App.logger.Warn(@$"Key {key.ToString()} was not found");
+                    App.logger.Warn(@$"Key ""HKLM\SOFTWARE\AtlasOS\Toolbox\Favorites"" was not found");
                 }
             }
             if (_configurationItems.Count == 0)

--- a/AtlasToolbox/Views/IncompatibleVersionWindow.xaml.cs
+++ b/AtlasToolbox/Views/IncompatibleVersionWindow.xaml.cs
@@ -29,14 +29,14 @@ namespace AtlasToolbox
     {
         public IncompatibleVersionWindow()
         {
-            WindowManager.Get(this).IsMaximizable = false;
-            WindowManager.Get(this).IsResizable = false;
+            //WindowManager.Get(this).IsMaximizable = false;
+            //WindowManager.Get(this).IsResizable = false;
             WindowManager.Get(this).Width = 1250;
             WindowManager.Get(this).Height = 850;
             CenterWindowOnScreen();
             ExtendsContentIntoTitleBar = true;
-            LoadText();
             this.InitializeComponent();
+            LoadText();
         }
 
         private void LoadText()

--- a/AtlasToolbox/Views/SettingsPage.xaml
+++ b/AtlasToolbox/Views/SettingsPage.xaml
@@ -52,6 +52,13 @@
                                 Margin="0,0,16,0"
                                 VerticalAlignment="Center"
                                 Visibility="Collapsed" />
+                            <ProgressRing
+                                x:Name="ProgressRing"
+                                Width="20"
+                                Height="20"
+                                Margin="0,0,10,0"
+                                IsActive="True"
+                                Visibility="Collapsed" />
                             <Button x:Name="CheckUpdateButton" Click="CheckUpdateButton_Click" />
                         </StackPanel>
                     </controls:SettingsCard>

--- a/AtlasToolbox/Views/SettingsPage.xaml.cs
+++ b/AtlasToolbox/Views/SettingsPage.xaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
+using System.Threading.Tasks;
 using AtlasToolbox.Utils;
 using AtlasToolbox.ViewModels;
 using Microsoft.UI.Xaml;
@@ -77,11 +78,15 @@ namespace AtlasToolbox.Views
             App.ContentDialogCaller("restartApp");
         }
 
-        private void CheckUpdateButton_Click(object sender, RoutedEventArgs e)
+        private async void CheckUpdateButton_Click(object sender, RoutedEventArgs e)
         {
-            SettingsPageViewModel vm = this.DataContext as SettingsPageViewModel;   
-            if (vm.CheckUpdates())
+            SettingsPageViewModel vm = this.DataContext as SettingsPageViewModel;
+            NoUpdatesBar.Visibility = Visibility.Collapsed;
+            ProgressRing.Visibility = Visibility.Visible;
+            bool update = await Task.Run(() => vm.CheckUpdates());
+            if (update)
             {
+                ProgressRing.Visibility = Visibility.Collapsed;
                 NoUpdatesBar.Visibility = Visibility.Visible;
             }
         }

--- a/AtlasToolbox/app.config
+++ b/AtlasToolbox/app.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
 	<appSettings>
-		<add key="AtlasVersion" value="0.5.0"/>
+		<add key="AtlasVersion" value="0.4.1,0.5.0"/>
 		<add key="ToolboxVersion" value="v0.1.8 Beta"/>
 	</appSettings>
 </configuration>

--- a/AtlasToolbox/app.config
+++ b/AtlasToolbox/app.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
 	<appSettings>
-		<add key="AtlasVersion" value="0.4.1"/>
-		<add key="ToolboxVersion" value="v0.1.6 Beta"/>
+		<add key="AtlasVersion" value="0.5.0"/>
+		<add key="ToolboxVersion" value="v0.1.8 Beta"/>
 	</appSettings>
 </configuration>

--- a/AtlasToolbox/lang/en_us.json
+++ b/AtlasToolbox/lang/en_us.json
@@ -202,5 +202,7 @@
     "InstallNow": "Install now",
     "WindowsHello": "Windows Hello",
     "NoFavorites": "You have not added anything to your favorites yet.",
-    "SystemInfo": "About this system:"
+    "SystemInfo": "About this system:",
+    "NewUpdateMessage": "There is a new update available.",
+    "LearnMore": "Learn more"
 }

--- a/AtlasToolbox/lang/fr_fr.json
+++ b/AtlasToolbox/lang/fr_fr.json
@@ -200,6 +200,7 @@
     "InstallNow": "Installer maintenent",
     "WindowsHello": "Windows Hello",
     "NoFavorites": "Vous n'avez rien ajouté à votre liste des favoris.",
-    "SystemInfo": "À propos de ce système:"
-
+    "SystemInfo": "À propos de ce système:",
+    "NewUpdateMessage": "Une nouvelle mise-à-jour est disponible.",
+    "LearnMore": "En savoir plus"
 }

--- a/AtlasToolbox/lang/ru-ru.json
+++ b/AtlasToolbox/lang/ru-ru.json
@@ -201,7 +201,9 @@
     "NewUpdateDesc": "Доступно новое обновление. Установить сейчас?",
     "InstallNow": "Установить сейчас",
     "WindowsHello": "Windows Hello",
-    "NoFavorites": "You have not marked anything as favorite yet. (to be translated)",
-    "SystemInfo": "About this system: (to be translated)"
+    "NoFavorites": "You have not added anything as favorite yet. (to be translated)",
+    "SystemInfo": "About this system: (to be translated)",
+    "NewUpdateMessage": "A new update is available (to be translated)",
+    "LearnMore": "Learn more (to be translated)"
 
 }

--- a/AtlasToolbox/lang/sv_se.json
+++ b/AtlasToolbox/lang/sv_se.json
@@ -201,6 +201,8 @@
     "NewUpdateDesc": "There is a new update available. Would you like to install it now ? (to be translated)",
     "InstallNow": "Install now (to be translated)",
     "WindowsHello": "Windows Hello",
-    "NoFavorites": "You have not marked anything as favorite yet. (to be translated)",
-    "SystemInfo": "About this system: (to be translated)"
+    "NoFavorites": "You have not added anything as favorite yet. (to be translated)",
+    "SystemInfo": "About this system: (to be translated)",
+    "NewUpdateMessage": "A new update is available. (to be translated)",
+    "LearnMore": "Learn more (to be translated)"
 }


### PR DESCRIPTION
# :toolbox: Atlas Toolbox Beta Release v0.1.8
We are happy to announce the release the seventh Beta for the Atlas Toolbox. This update brings improvements to existing features as well as bug fixes
## :pencil: Changelog
### Bug Fixes
- Fixed troubleshooting buttons not working
- Fixed the app crashing when opening on an incompatible version
- Fixed Window size being too large for certain screens
### Feature improvements
- Toolbox no longer hangs whilst checking for an update
- Toolbox now checks for updates on startup and gives a notification if an update is found
- Removed navigation bar warnings.
- Added 0.5.0 support.
## Installing
If you are on **Beta 0.1.6 or later**, you will be able to upgrade directly to Beta 0.1.8.
If you are on a **previous version or haven't installed Toolbox yet**, use the installer found in our [release files](https://github.com/Atlas-OS/atlas-toolbox/releases/latest).