### PR TITLE
Fix #52 & Atlas-OS/Atlas#1594

### DIFF
--- a/AtlasToolbox/Services/ConfigurationServices/SearchIndexingConfigurationService.cs
+++ b/AtlasToolbox/Services/ConfigurationServices/SearchIndexingConfigurationService.cs
@@ -24,7 +24,7 @@ namespace AtlasToolbox.Services.ConfigurationServices
         public void Disable()
         {
             ServiceHelper.SetStartupType(WSEARCH_SERVICE_NAME, ServiceStartMode.Disabled);
-            RegistryHelper.SetValue(ATLAS_STORE_KEY_NAME, STATE_VALUE_NAME, 1);
+            RegistryHelper.SetValue(ATLAS_STORE_KEY_NAME, STATE_VALUE_NAME, 0);
 
             _searchIndexingConfigurationStore.CurrentSetting = IsEnabled();
         }
@@ -32,7 +32,7 @@ namespace AtlasToolbox.Services.ConfigurationServices
         public void Enable()
         {
             ServiceHelper.SetStartupType(WSEARCH_SERVICE_NAME, ServiceStartMode.Automatic);
-            RegistryHelper.SetValue(ATLAS_STORE_KEY_NAME, STATE_VALUE_NAME, 0);
+            RegistryHelper.SetValue(ATLAS_STORE_KEY_NAME, STATE_VALUE_NAME, 1);
 
             _searchIndexingConfigurationStore.CurrentSetting = IsEnabled();
         }

--- a/AtlasToolbox/Services/ConfigurationServices/WindowsHelloConfigurationServices.cs
+++ b/AtlasToolbox/Services/ConfigurationServices/WindowsHelloConfigurationServices.cs
@@ -40,6 +40,7 @@ namespace AtlasToolbox.Services.ConfigurationServices
             RegistryHelper.SetValue(FACIAL_FEATURES_KEY_NAME, ENABLED_VALUE_NAME, 0, Microsoft.Win32.RegistryValueKind.DWord);
             RegistryHelper.SetValue(FINGERPRINT_FEATURES_KEY_NAME, ENABLED_VALUE_NAME, 0, Microsoft.Win32.RegistryValueKind.DWord);
             RegistryHelper.SetValue(ALLOW_SIGN_IN_OPTIONS_KEY_NAME, VALUE_VALUE_NAME, 0, Microsoft.Win32.RegistryValueKind.DWord);
+            RegistryHelper.SetValue(ATLAS_STORE_KEY_NAME, STATE_VALUE_NAME, 0);
 
             configurationStore.CurrentSetting = IsEnabled();
         }
@@ -52,6 +53,7 @@ namespace AtlasToolbox.Services.ConfigurationServices
             RegistryHelper.SetValue(FACIAL_FEATURES_KEY_NAME, ENABLED_VALUE_NAME, 1, Microsoft.Win32.RegistryValueKind.DWord);
             RegistryHelper.SetValue(FINGERPRINT_FEATURES_KEY_NAME, ENABLED_VALUE_NAME, 1, Microsoft.Win32.RegistryValueKind.DWord);
             RegistryHelper.SetValue(ALLOW_SIGN_IN_OPTIONS_KEY_NAME, VALUE_VALUE_NAME, 1, Microsoft.Win32.RegistryValueKind.DWord);
+            RegistryHelper.SetValue(ATLAS_STORE_KEY_NAME, STATE_VALUE_NAME, 1);
 
             configurationStore.CurrentSetting = IsEnabled();
         }


### PR DESCRIPTION
these 2 issues were about the toggle resetting even though the change did apply, this was due to 2 different reasons related to the STATE_VALUE_NAME toggle:

with Search indexing the Value was set incorrectly on enable and disable, flipping them around should fix this issue

In Atlas#1594 this was caused by the Function to change the value simply not existing, adding them should fix this issue(as it does check it in IsEnabled())

Overall a simple fix.