### PR TITLE
fix: restart Explorer so the legacy context menu toggle takes effect

### DIFF
--- a/AtlasToolbox/Services/ConfigurationServices/OldContextMenuConfigurationService.cs
+++ b/AtlasToolbox/Services/ConfigurationServices/OldContextMenuConfigurationService.cs
@@ -32,6 +32,8 @@ namespace AtlasToolbox.Services.ConfigurationServices
 
             RegistryHelper.SetValue(ATLAS_STORE_KEY_NAME, STATE_VALUE_NAME, 0);
 
+            CommandPromptHelper.RestartExplorer();
+
             _oldContextMenuConfigurationService.CurrentSetting = IsEnabled();
         }
 
@@ -41,12 +43,16 @@ namespace AtlasToolbox.Services.ConfigurationServices
 
             RegistryHelper.SetValue(ATLAS_STORE_KEY_NAME, STATE_VALUE_NAME, 1);
 
+            CommandPromptHelper.RestartExplorer();
+
             _oldContextMenuConfigurationService.CurrentSetting = IsEnabled();
         }
 
         public bool IsEnabled()
         {
-            return RegistryHelper.IsMatch(ATLAS_STORE_KEY_NAME, STATE_VALUE_NAME, 1);
+            // The InprocServer32 key is the actual switch Explorer reads; the Atlas
+            // state value can drift out of sync when the key is changed externally.
+            return RegistryHelper.KeyExists(INCROP_SERVER_32);
         }
     }
 }

--- a/AtlasToolbox/Services/ConfigurationServices/OldContextMenuConfigurationService.cs
+++ b/AtlasToolbox/Services/ConfigurationServices/OldContextMenuConfigurationService.cs
@@ -50,9 +50,7 @@ namespace AtlasToolbox.Services.ConfigurationServices
 
         public bool IsEnabled()
         {
-            // The InprocServer32 key is the actual switch Explorer reads; the Atlas
-            // state value can drift out of sync when the key is changed externally.
-            return RegistryHelper.KeyExists(INCROP_SERVER_32);
+            return RegistryHelper.IsMatch(ATLAS_STORE_KEY_NAME, STATE_VALUE_NAME, 1);
         }
     }
 }


### PR DESCRIPTION
## Problem

The **Legacy context menu (pre-Windows 11)** toggle appears to do nothing. The registry write itself works (visible in the toolbox log), but `Enable()` / `Disable()` never restart Explorer, and the `InprocServer32` CLSID tweak only takes effect once `explorer.exe` restarts. Users toggle it, see no change, and flip it back assuming it is broken.

## Fix

Call `CommandPromptHelper.RestartExplorer()` (the same helper the Restart Explorer button uses) at the end of `Enable()` and `Disable()`, so the menu change applies immediately.

`IsEnabled()` is left reading the `HKLM\SOFTWARE\AtlasOS\Services\OldContextMenu\state` value, per review — the toolbox uses that to keep track of states.

## Testing

Built and ran the patched toolbox on Atlas OS (Windows 11 Pro 26200): toggling in either direction now restarts Explorer and the new menu state is active immediately, in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
